### PR TITLE
Allow postData for content

### DIFF
--- a/src/geojsonlayer.js
+++ b/src/geojsonlayer.js
@@ -34,6 +34,7 @@ define([
             this._validState = true;
             // First look for url
             this._url = options.url;
+            this._postData = options.postData;
             // Accept data as geojson features array. This will override options.url!
             this._data = options.data;
             // GeoJSON spatial reference (not optional)
@@ -172,6 +173,8 @@ define([
             // xhr request to get data
             var requestHandle = esriRequest({
                 url: url,
+                content: this._postData,
+                usePost: this._postData != null,
                 handleAs: "json"
             });
             requestHandle.then(lang.hitch(this, this._getGeoJson),


### PR DESCRIPTION
We have a geojson endpoint which requires a POST in order to filter appropriate data.